### PR TITLE
Normalize calendar icon color

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -169,6 +169,7 @@ const useHoverInfoLabelStyles = makeStyles({
   icon: {
     marginRight: '0.2rem',
     marginLeft: '0.2rem',
+    color: 'unset !important',
   },
 });
 


### PR DESCRIPTION
# Description: 
In some pages the `mdi:calendar` icon is displayed with a wrong color in both dark and light themes.

# Changes: 
- [x]  Force the unset color property on the icon.